### PR TITLE
perf(flat): O(1) branch descent + FxHash storage-views map (CPU-13 follow-up)

### DIFF
--- a/crates/mpt/src/flat.rs
+++ b/crates/mpt/src/flat.rs
@@ -16,7 +16,7 @@
 
 use std::borrow::Cow;
 
-use alloy_primitives::{map::HashMap, B256};
+use alloy_primitives::{map::{B256Map, HashMap}, B256};
 use alloy_rlp::Encodable;
 use reth_trie::HashedPostState;
 use serde::{Deserialize, Serialize};
@@ -125,7 +125,7 @@ impl FlatEthereumState<'_> {
     pub fn views(&self) -> Result<FlatStateViews<'_>, Error> {
         let state = FlatTrieView::parse_and_verify(&self.state_nodes)?;
         let mut storage =
-            HashMap::with_capacity_and_hasher(self.storage_tries.len(), Default::default());
+            B256Map::with_capacity_and_hasher(self.storage_tries.len(), Default::default());
         for entry in &self.storage_tries {
             storage.insert(entry.hashed_address, FlatTrieView::parse_and_verify(&entry.nodes)?);
         }
@@ -849,7 +849,7 @@ fn match_prefix(prefix: &[u8], key: &[u8], mut pos: usize) -> Option<usize> {
 #[derive(Debug)]
 pub struct FlatStateViews<'a> {
     pub state: FlatTrieView<'a>,
-    pub storage: HashMap<B256, FlatTrieView<'a>>,
+    pub storage: B256Map<FlatTrieView<'a>>,
 }
 
 impl FlatStateViews<'_> {

--- a/crates/mpt/src/flat.rs
+++ b/crates/mpt/src/flat.rs
@@ -639,6 +639,21 @@ impl<'a> FlatTrieView<'a> {
                     }
                     let slot = nib_at(key, pos) as usize;
                     pos += 1;
+
+                    // Fast path: a resolved digest child's node index is already in the edge
+                    // table (recorded during verification), so descend in O(1) without
+                    // rescanning the branch payload. This covers the entire interior of the
+                    // descent; only inline/empty/pruned slots fall back to the O(slot) parse.
+                    if !inline {
+                        let edge =
+                            self.edges[self.nodes[node_idx as usize].edge_start as usize + slot];
+                        if edge != EDGE_PRUNED {
+                            node_idx = edge;
+                            blob = self.blob(edge);
+                            continue;
+                        }
+                    }
+
                     match branch_child(payload, slot)? {
                         FlatRef::Empty => return Ok(None),
                         FlatRef::Inline(b) => {
@@ -649,13 +664,9 @@ impl<'a> FlatTrieView<'a> {
                             if inline {
                                 return Err(Error::FlatTrie("digest ref inside inline node"));
                             }
-                            let edge = self.edges
-                                [self.nodes[node_idx as usize].edge_start as usize + slot];
-                            if edge == EDGE_PRUNED {
-                                return Ok(None);
-                            }
-                            node_idx = edge;
-                            blob = self.blob(edge);
+                            // Not inline: the edge was EDGE_PRUNED (else the fast path took it),
+                            // so this digest child is a pruned subtree — absent from the witness.
+                            return Ok(None);
                         }
                     }
                 }


### PR DESCRIPTION
Two independent, measured cycle optimizations to the flat-RLP witness trie, on top of #12 (CPU-13 flat RLP witness format). Both are confined to `crates/mpt/src/flat.rs`.

## Changes

**1. O(1) branch descent in `FlatTrieView::get`** (`0d20380`)
`get()` called `branch_child(payload, slot)` on every branch descent, which rescans the branch payload from item 0 up to `slot` (O(slot) RLP-header parses). Keccak-hashed keys make branches wide (avg slot ~8) and tries deep, so that rescan dominated cold lookups. The resolved-digest child index is already recorded in the edge table during verification, so the interior of every descent now goes straight to the child blob in O(1); only inline/empty/pruned slots (rare, near the leaves) fall back to the payload scan. Behavior is identical — a non-pruned edge is exactly a matched digest child, and the inline-digest/pruned cases are preserved.

**2. FxHash-backed B256 map for per-account storage views** (`ccea74a`)
`FlatStateViews.storage` (hashed-address → storage-trie view, queried on every cold storage/account access) used alloy's default foldhash, which costs ~246 cyc per 32-byte key on the RV64 zkVM guest. Switched to alloy's `B256Map` (FxHash-backed `FbBuildHasher`), the purpose-built fast hasher for `B256` keys.

## Impact (reth block 18884864, RV64 guest)

Measured on stock revm to isolate this branch's effect:

| | total cycles |
| --- | --- |
| baseline (merged #12) | 50,518,757 |
| this branch | **49,909,441 (−0.61M)** |

Split: branch descent −0.41M (block execution 33.25M → 32.95M), storage-views hasher −0.20M. The two are additive and independent of any revm-side change.

## Correctness

- All `rsp-mpt` flat-trie parity tests pass (incl. the randomized `get`/materialize sweeps against the `MptNode` reference).
- All four rv64 bench blocks (17106222, 18884864, 23993050, 24600825) execute natively with matching state roots, and the in-guest run passes its post-state-root check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)